### PR TITLE
Add health check endpoint and improve CI workflow with container testing

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -28,6 +28,7 @@ env:
   IMAGE_NAME: icicle-ai/fass-back
 
 jobs:
+
   build-and-push-images:
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +62,27 @@ jobs:
         with:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.get_tag_name.outputs.tag_name }}
+      
+      - name: Test container starts successfully
+        run: |
+            docker run -d -p 8000:8000 --name test-container ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.get_tag_name.outputs.tag_name }}
+            timeout=30
+            interval=5
+            elapsed=0
 
+            until curl -s http://localhost:8080/health; do
+              if [ "$elapsed" -ge "$timeout" ]; then
+                echo "Health check failed: container did not become ready within $timeout seconds"
+                exit 1
+              fi
+              echo "Waiting for container to be ready..."
+              sleep $interval
+              elapsed=$((elapsed + interval))
+            done
+
+            echo "Container is healthy!"
+            docker stop test-container
+  
   deploy-images-staging:
     runs-on: ubuntu-latest
     needs: [build-and-push-images]

--- a/food_access_model/api/routes.py
+++ b/food_access_model/api/routes.py
@@ -252,6 +252,16 @@ async def get_household_stats(repository: DBRepository = Depends(get_db_reposito
     return {"avg_income": avg_income, "avg_vehicles": avg_vehicles}
 
 
+@router.get("/health")
+async def health_check(repository: DBRepository = Depends(get_db_repository)):
+    """Health check endpoint to verify the API is running properly"""
+    try:
+        # Basic check that we can access the model
+        model = repository.get_model()
+        return {"status": "healthy", "message": "API is operational"}
+    except Exception as e:
+        logging.error(f"Health check failed: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Health check failed: {str(e)}")
 
 
 


### PR DESCRIPTION
Adding in an additional job to the github workflow that checks out and runs the container, and checks a (new) health route. This job checks every five seconds for up to 30 seconds before failing. This is to ensure that the latest version of the container builds and starts before trying to deploy it in the subsequent job.

NOTE: I don't have the gihub secrets, so I wasn't able to test this locally. I think we'll have to do this on the fly - otherwise, open to suggestions.