### PR TITLE
Brown County Pivot & Simulation Schema Migration

### DIFF
--- a/food_access_model/preprocessing/brown_county_get_data.py
+++ b/food_access_model/preprocessing/brown_county_get_data.py
@@ -29,6 +29,8 @@ from shapely.strtree import STRtree
 from pyproj import Transformer
 from dotenv import load_dotenv 
 
+INCLUDE_CENSUS_STORES = False
+STORES_CSV = "BC_stores.csv"
 
 # Local Application Imports
 from household_constants import (
@@ -393,17 +395,21 @@ def process_food_stores(
     Returns:
         STRtree: Spatial index of all geometric elements including food stores.
     """
-    features = ox.features.features_from_point(
-        center_point,
-        dist=dist * 3,
-        tags={"shop": [
-            "convenience", "supermarket", "butcher", "wholesale",
-            "farm", "greengrocer", "health_food", "grocery"
-        ]}
-    )
-
-    features = features.to_crs("epsg:3857")
-    features = features[["shop", "geometry", "name"]]
+    if INCLUDE_CENSUS_STORES:
+        features = ox.features.features_from_point(
+            center_point,
+            dist=dist * 3,
+            tags={"shop": [
+                "convenience", "supermarket", "butcher", "wholesale",
+                "farm", "greengrocer", "health_food", "grocery"
+            ]}
+        )
+        features = features.to_crs("epsg:3857")
+        features = features[["shop", "geometry", "name"]]
+    else:
+        import geopandas as gpd
+        features = gpd.GeoDataFrame(columns=["shop", "geometry", "name"], geometry="geometry")
+        logging.info("INCLUDE_CENSUS_STORES=False — skipping OpenStreetMap store fetch.")
 
     store_tuples_strPoly: List[Tuple] = []
     store_tuples_Poly: List[Tuple] = []
@@ -895,11 +901,12 @@ def process_housing_areas(
                         logging.warning(f"First attribute assignment error: {e}")
                     continue
 
-                nearest_store = get_nearest_store(house, store_tuples, shapely.wkt.loads)
-                if nearest_store is None:
-                    failed_store += 1
-                    continue
-                
+                if store_tuples:
+                    nearest_store = get_nearest_store(house, store_tuples, shapely.wkt.loads)
+                    if nearest_store is None:
+                        failed_store += 1
+                        continue
+
                 success += 1
 
                 house_4326 = transform_polygon_coords(house, "EPSG:3857", "EPSG:4326")
@@ -1073,17 +1080,26 @@ def main() -> None:
         connection.rollback()
         raise
 
-    logging.info("Inserting food stores...")
-    food_stores_query = "INSERT INTO food_stores (simulation_instance, simulation_step, shop, geometry, name, store_id) VALUES %s"
-    # Update store tuples with simulation_instance_id
-    store_tuples_with_id = [(simulation_instance_id, step, shop, geom, name, sid) 
-                            for (_, step, shop, geom, name, sid) in simulation_data['stores']]
-    try:
-        extras.execute_values(cursor, food_stores_query, store_tuples_with_id)
-    except psycopg2.Error as e:
-        logging.error(f"Food stores insertion failed: {e}")
-        connection.rollback()
-        raise
+    if INCLUDE_CENSUS_STORES:
+        logging.info("Inserting census food stores from OpenStreetMap...")
+        food_stores_query = "INSERT INTO food_stores (simulation_instance, simulation_step, shop, geometry, name, store_id) VALUES %s"
+        store_tuples_with_id = [(simulation_instance_id, step, shop, geom, name, sid) 
+                                for (_, step, shop, geom, name, sid) in simulation_data['stores']]
+        try:
+            extras.execute_values(cursor, food_stores_query, store_tuples_with_id)
+        except psycopg2.Error as e:
+            logging.error(f"Food stores insertion failed: {e}")
+            connection.rollback()
+            raise
+    else:
+        logging.info("INCLUDE_CENSUS_STORES=False — inserting curated local stores...")
+        import subprocess
+        insert_script = os.path.join(os.path.dirname(__file__), '..', '..', 'insert_stores.py')
+        result = subprocess.run([sys.executable, insert_script, STORES_CSV], capture_output=True, text=True)
+        if result.returncode == 0:
+            logging.info(f"insert_stores.py completed successfully:\n{result.stdout}")
+        else:
+            logging.error(f"insert_stores.py failed:\n{result.stderr}")
 
     logging.info("Inserting households into the database...")
     # Update household tuples with simulation_instance_id


### PR DESCRIPTION
I've pivoted the simulation data to Brown County and implemented the new database schema we discussed. This version handles the stakeholder requirement to filter out generic stores and optimizes how we track agents over time.

What I did:
Store Filtering: Added an INCLUDE_CENSUS_STORES toggle. It’s set to False by default to omit generic census stores for Brown County while keeping all households.

Schema Migration: Split the old simulation_step into start_step and end_step using Steve's instructions. This allows us to handle persisting agents by setting end_step to NULL, saving us a ton of database bloat.

As you can see in the screenshot, the simulation successfully advances to Step 1 on the new fass_bc database. The Avg Household Vehicles stat updated to 0.50, which proves the backend is correctly calculating and saving the new states. I tested it by manually inserting.

NOTE the db is called fass_bc in env 

<img width="869" height="269" alt="Screenshot 2026-02-20 at 6 26 22 PM" src="https://github.com/user-attachments/assets/e68fc304-c308-4fa1-bb09-4ae3424b3c85" />

