### PR TITLE
INCLUDE_CENSUS_STORES toggle to filter census stores (#64)

### DIFF
--- a/food_access_model/preprocessing/get_data.py
+++ b/food_access_model/preprocessing/get_data.py
@@ -29,6 +29,8 @@ from shapely.strtree import STRtree
 from pyproj import Transformer
 from dotenv import load_dotenv 
 
+INCLUDE_OSM_STORES = False
+STORES_CSV = "BC_stores.csv"
 
 # Local Application Imports
 from household_constants import (
@@ -427,44 +429,72 @@ def process_food_stores(
             - List: Store tuples with Polygon geometries.
             - List[Tuple]: Store tuples with string geometries for SQL insertion.
     """
-    features = ox.features.features_from_point(
-        center_point,
-        dist=dist * 3,
-        tags={"shop": [
-            "convenience", "supermarket", "butcher", "wholesale",
-            "farm", "greengrocer", "health_food", "grocery"
-        ]}
-    )
-
-    features = features.to_crs("epsg:3857")
-    features = features[["shop", "geometry", "name"]]
-
     store_tuples_strPoly: List[Tuple] = []
     store_tuples_Poly: List[Tuple] = []
-
     store_id = 0
-    for row in features.itertuples():
-        point = row.geometry.centroid if not isinstance(row.geometry, Point) else row.geometry
 
-        if row.shop in ["supermarket", "grocery", "greengrocer"]:
-            polygon = Polygon([
-                (point.x + 50 * math.cos(math.radians(angle)), point.y + 50 * math.sin(math.radians(angle)))
-                for angle in range(0, 360, 60)
-            ])
-        else:
-            polygon = Polygon([
-                (point.x, point.y + 20),
-                (point.x + 25, point.y - 30),
-                (point.x - 25, point.y - 30)
-            ])
+    if INCLUDE_OSM_STORES:
+        features = ox.features.features_from_point(
+            center_point,
+            dist=dist * 3,
+            tags={"shop": [
+                "convenience", "supermarket", "butcher", "wholesale",
+                "farm", "greengrocer", "health_food", "grocery"
+            ]}
+        )
+        features = features.to_crs("epsg:3857")
+        features = features[["shop", "geometry", "name"]]
 
-        map_elements.append(polygon.buffer(20))
-        # New format: (simulation_instance, simulation_step, shop, geometry, name, store_id)
-        store_tuples_strPoly.append((None, 0, str(row.shop), str(polygon), str(row.name), store_id))
-        store_tuples_Poly.append((None, 0, str(row.shop), polygon, str(row.name), store_id))
-        store_id += 1
-    
-    return (STRtree(map_elements),store_tuples_Poly, store_tuples_strPoly)  
+        for row in features.itertuples():
+            point = row.geometry.centroid if not isinstance(row.geometry, Point) else row.geometry
+
+            if row.shop in ["supermarket", "grocery", "greengrocer"]:
+                polygon = Polygon([
+                    (point.x + 50 * math.cos(math.radians(angle)), point.y + 50 * math.sin(math.radians(angle)))
+                    for angle in range(0, 360, 60)
+                ])
+            else:
+                polygon = Polygon([
+                    (point.x, point.y + 20),
+                    (point.x + 25, point.y - 30),
+                    (point.x - 25, point.y - 30)
+                ])
+
+            map_elements.append(polygon.buffer(20))
+            store_tuples_strPoly.append((None, 0, str(row.shop), str(polygon), str(row.name), store_id))
+            store_tuples_Poly.append((None, 0, str(row.shop), polygon, str(row.name), store_id))
+            store_id += 1
+    else:
+        logging.info("INCLUDE_OSM_STORES=False — loading curated stores from %s", STORES_CSV)
+        transformer = Transformer.from_crs("epsg:4326", "epsg:3857", always_xy=True)
+        csv_path = os.path.join(os.path.dirname(__file__), STORES_CSV)
+        df = pd.read_csv(csv_path)
+
+        for _, row in df.iterrows():
+            lon, lat = transformer.transform(float(row['lat']), float(row['long']))
+            shop_type = str(row['Type'])[:15]
+            store_name = str(row['Name'])[:50]
+
+            if shop_type in ["supermarket", "grocery", "greengrocer"]:
+                polygon = Polygon([
+                    (lon + 50 * math.cos(math.radians(angle)), lat + 50 * math.sin(math.radians(angle)))
+                    for angle in range(0, 360, 60)
+                ])
+            else:
+                polygon = Polygon([
+                    (lon, lat + 20),
+                    (lon + 25, lat - 30),
+                    (lon - 25, lat - 30)
+                ])
+
+            map_elements.append(polygon.buffer(20))
+            store_tuples_strPoly.append((None, 0, shop_type, str(polygon), store_name, store_id))
+            store_tuples_Poly.append((None, 0, shop_type, polygon, store_name, store_id))
+            store_id += 1
+
+        logging.info("Loaded %d curated stores from CSV", store_id)
+
+    return (STRtree(map_elements), store_tuples_Poly, store_tuples_strPoly)  
 
 def get_household_insert_query() -> str:
     """
@@ -1071,7 +1101,6 @@ def main() -> None:
 
     logging.info("Inserting food stores...")
     food_stores_query = "INSERT INTO food_stores (simulation_instance, simulation_step, shop, geometry, name, store_id) VALUES %s"
-    # Update store tuples with simulation_instance_id
     store_tuples_with_id = [(simulation_instance_id, step, shop, geom, name, sid) 
                             for (_, step, shop, geom, name, sid) in simulation_data['stores']]
     try:


### PR DESCRIPTION
Adds an INCLUDE_CENSUS_STORES toggle to brown_county_get_data.py to address Brown County stakeholder's request to only display their curated local stores on the map, not generic census stores from OpenStreetMap.

INCLUDE_CENSUS_STORES toggle (default: False) — when False, the preprocessing script skips the OpenStreetMap store fetch and automatically runs insert_stores.py to load curated stores from BC_stores.csv. When True, original census store behavior is preserved.

STORES_CSV variable — configurable path to the curated stores CSV file.
Household guard — added a safety check in process_housing_areas() so all 7,381 households are always generated even when no census stores are loaded.

figures show sample data and the difference between the first one which is include_census = false and the second which is include_census = true 

<img width="1725" height="857" alt="Screenshot 2026-02-24 at 6 19 32 PM" src="https://github.com/user-attachments/assets/276ff2eb-e8ae-45bc-ae9d-6e5dfe40bb9c" />

<img width="1726" height="866" alt="Screenshot 2026-02-24 at 6 19 39 PM" src="https://github.com/user-attachments/assets/076bae41-888c-4542-ac0b-01251cb88518" />
