### PR TITLE
Mvp county generalizability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,12 @@ NUMBER_PROCESSES=8 #example number
 
 #API config
 APIKEY="an_api_key"
+
+# Instance config
+PLACE_NAME="Place Name, State, Country" 
+FIPSCODE=12345 #example FIPS code
+YEAR=2022 #example year
+CENTER_LAT=0.0 #example latitude
+CENTER_LON=0.0 #example longitude
+INCLUDE_OSM_STORES=False
+STORES_CSV="stores.csv" #example stores csv file (LEAVE BLANK IF NONE)

--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,6 @@ DB_PASS="database_password"
 DB_HOST="localhost"
 DB_PORT=1234 #example port
 
-# Number of worker processes to run
-NUMBER_PROCESSES=8 #example number
-
-#API config
-APIKEY="an_api_key"
-
 # Instance config
 PLACE_NAME="Place Name, State, Country" 
 FIPSCODE=12345 #example FIPS code
@@ -19,3 +13,9 @@ CENTER_LAT=0.0 #example latitude
 CENTER_LON=0.0 #example longitude
 INCLUDE_OSM_STORES=False
 STORES_CSV="stores.csv" #example stores csv file (LEAVE BLANK IF NONE)
+
+# Number of worker processes to run
+NUMBER_PROCESSES=8 #example number
+
+#API config
+APIKEY="an_api_key"

--- a/food_access_model/api/routes.py
+++ b/food_access_model/api/routes.py
@@ -191,7 +191,6 @@ async def reset_simulation_instance(instance_id: str) -> ORJSONResponse:
 
 @router.post("/simulation-instances")
 async def create_simulation_instance(name: Optional[str] = Body(None, embed=True),
-                                     description: Optional[str] = Body(None, embed=True),
                                      household_limit: Optional[int] = Body(None, embed=True)) -> ORJSONResponse:
     """
     Create a new simulation instance.
@@ -207,6 +206,13 @@ async def create_simulation_instance(name: Optional[str] = Body(None, embed=True
     # Generate a name if not provided
     if name is None:
         name = generate_name()
+
+    description = json.dumps({
+        "place_name": os.getenv("PLACE_NAME", "Unknown"),
+        "center_lat": float(os.getenv("CENTER_LAT", 0.0)),
+        "center_lon": float(os.getenv("CENTER_LON", 0.0)),
+    })
+
     query = """
         INSERT INTO simulation_instances (name, description)
         VALUES ($1, $2)

--- a/food_access_model/preprocessing/get_data.py
+++ b/food_access_model/preprocessing/get_data.py
@@ -308,10 +308,10 @@ def initialize_database_tables(
     cursor.execute('''
     CREATE TABLE IF NOT EXISTS roads (
         name TEXT,
-        highway VARCHAR(30),
+        highway TEXT,
         length NUMERIC,
         geometry TEXT,
-        service VARCHAR(30)
+        service TEXT
     );
     ''')
     cursor.execute('''

--- a/food_access_model/preprocessing/get_data.py
+++ b/food_access_model/preprocessing/get_data.py
@@ -29,10 +29,14 @@ from shapely.geometry import Point, Polygon, LineString
 from shapely.ops import unary_union
 from shapely.strtree import STRtree
 from pyproj import Transformer
-from dotenv import load_dotenv 
+from dotenv import load_dotenv
 
-INCLUDE_OSM_STORES = False
-STORES_CSV = "BC_stores.csv"
+load_dotenv()
+
+INCLUDE_OSM_STORES = (
+    os.getenv("INCLUDE_OSM_STORES").lower() == "true"
+)
+STORES_CSV = os.getenv("STORES_CSV") or None
 
 # Local Application Imports
 from household_constants import (
@@ -44,9 +48,6 @@ from household_constants import (
     size_index_dict,
     workers_index_dict
 )
-
-
-load_dotenv()
 
 ox.settings.timeout = 180  # 3 minute timeout to prevent indefinite hangs
 

--- a/food_access_model/preprocessing/household_constants.py
+++ b/food_access_model/preprocessing/household_constants.py
@@ -1,9 +1,10 @@
+import os
 
-YEAR = 2022
-PLACE_NAME  = "Brown County, Wisconsin, USA"
+YEAR = int(os.getenv("YEAR", 2022))
+PLACE_NAME = os.getenv("PLACE_NAME")
 # Representative map center (lat, lon). Simulation extent is defined by census tract union for FIPSCODE.
-CENTER_POINT = (44.5, -88.0)
-FIPSCODE = "55009"
+CENTER_POINT = (float(os.getenv("CENTER_LAT")), float(os.getenv("CENTER_LON")))
+FIPSCODE = os.getenv("FIPSCODE")
 
 #Dictionary to describe homedata Variables
 households_variables_dict = {


### PR DESCRIPTION
Moved data paramaters to .env file for easier swap between counties.

The paramaters should be as follows in .env

# Instance config
PLACE_NAME="Place Name, State, Country" 
FIPSCODE=12345 #example FIPS code
YEAR=2022 #example year
CENTER_LAT=0.0 #example latitude
CENTER_LON=0.0 #example longitude
INCLUDE_OSM_STORES=False
STORES_CSV="stores.csv" #example stores csv file (LEAVE BLANK IF NONE)